### PR TITLE
Fixed NullPointerException in Creative Menu

### DIFF
--- a/src/main/java/com/greatorator/tolkienmobs/integration/curios/TTMCurioWrapper.java
+++ b/src/main/java/com/greatorator/tolkienmobs/integration/curios/TTMCurioWrapper.java
@@ -46,7 +46,13 @@ public class TTMCurioWrapper implements ICurio {
 
     @Override
     public List<ITextComponent> getTagsTooltip(List<ITextComponent> tagTooltips) {
-        return item.getTagsTooltip(stack, tagTooltips);
+    	if (item != null && stack != null) {
+    		return item.getTagsTooltip(stack, tagTooltips);
+    	}
+    	else if (tagTooltips != null) {
+    		return tagTooltips;
+    	}
+    	return null;
     }
 
     @Override


### PR DESCRIPTION
Fixed an crash when hovering over any registered Curios (like the Backpack) in the Creative Menu.